### PR TITLE
Using reference counting to manage TransportClient::PendingAssoc obje…

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -303,45 +303,37 @@ TransportClient::associate(const AssociationData& data, bool active)
               OPENDDS_STRING(tc_assoc).c_str(),
               OPENDDS_STRING(remote_new).c_str()), 0);
   } else {
-    if (iter->second->removed_) {
-      iter->second->removed_ = false;
-      GuidConverter tc_assoc(this->repo_id_);
-      GuidConverter remote_new(data.remote_id_);
-      VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::associate found existing PendingAssoc "
-                "between %C and remote %C, set removed to false to continue using this pending association\n",
-                OPENDDS_STRING(tc_assoc).c_str(),
-                OPENDDS_STRING(remote_new).c_str()), 0);
-    } else {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: TransportClient::associate ")
-                 ACE_TEXT("already associating with remote.\n")));
+    
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: TransportClient::associate ")
+               ACE_TEXT("already associating with remote.\n")));
 
-      return false;
-    }
+    return false;
+    
   }
 
-  PendingAssoc& pend = *(iter->second);
-  pend.active_ = active;
-  pend.impls_.clear();
-  pend.blob_index_ = 0;
-  pend.data_ = data;
-  pend.attribs_.local_id_ = repo_id_;
-  pend.attribs_.priority_ = get_priority_value(data);
-  pend.attribs_.local_reliable_ = reliable_;
-  pend.attribs_.local_durable_ = durable_;
+  PendingAssoc_rch pend = iter->second;
+  pend->active_ = active;
+  pend->impls_.clear();
+  pend->blob_index_ = 0;
+  pend->data_ = data;
+  pend->attribs_.local_id_ = repo_id_;
+  pend->attribs_.priority_ = get_priority_value(data);
+  pend->attribs_.local_reliable_ = reliable_;
+  pend->attribs_.local_durable_ = durable_;
 
   if (active) {
-    pend.impls_.reserve(impls_.size());
+    pend->impls_.reserve(impls_.size());
     std::reverse_copy(impls_.begin(), impls_.end(),
-                      std::back_inserter(pend.impls_));
+                      std::back_inserter(pend->impls_));
 
-    return pend.initiate_connect(this, guard);
+    return pend->initiate_connect(this, guard);
 
   } else { // passive
 
     // call accept_datalink for each impl / blob pair of the same type
     for (size_t i = 0; i < impls_.size(); ++i) {
-      pend.impls_.push_back(impls_[i]);
+      pend->impls_.push_back(impls_[i]);
       const OPENDDS_STRING type = impls_[i]->transport_type();
 
       for (CORBA::ULong j = 0; j < data.remote_data_.length(); ++j) {
@@ -358,7 +350,7 @@ TransportClient::associate(const AssociationData& data, bool active)
             // Event handlers in the transport reactor may call passive_connection which calls use_datalink which acquires lock_.  The locking order in this case is transport reactor lock -> lock_.
             // To avoid deadlock, we must reverse the lock.
             ACE_GUARD_RETURN(Reverse_Lock_t, unlock_guard, reverse_lock_, false);
-            res = impls_[i]->accept_datalink(remote, pend.attribs_, this);
+            res = impls_[i]->accept_datalink(remote, pend->attribs_, this);
           }
 
           //NEED to check that pend is still valid here after you re-acquire the lock_ after accepting the datalink
@@ -379,7 +371,7 @@ TransportClient::associate(const AssociationData& data, bool active)
         }
       }
 
-      //pend.impls_.push_back(impls_[i]);
+      //pend->impls_.push_back(impls_[i]);
     }
 
     pending_assoc_timer_->schedule_timer(this, iter->second);
@@ -441,37 +433,6 @@ TransportClient::initiate_connect_i(TransportImpl::AcceptConnectResult& result,
     }
   }
 
-  //Check to make sure the pending assoc still exists in the map and hasn't been slated for removal
-  //figure out how to respond to these possible results that occurred while lock was released to connect
-  PendingMap::iterator iter = pending_.find(remote.repo_id_);
-
-  if (iter == pending_.end()) {
-    GuidConverter local(repo_id_);
-    GuidConverter remote_conv(remote.repo_id_);
-    VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::initiate_connect_i - "
-                        "cannot find pending association after connecting datalink between local %C and remote %C\n",
-                        OPENDDS_STRING(local).c_str(),
-                        OPENDDS_STRING(remote_conv).c_str()), 0);
-    return false;
-    //log some sort of error message...
-    //PendingAssoc's are only erased from pending_ in use_datalink_i after
-
-  } else {
-    if (iter->second->removed_) {
-      GuidConverter local(repo_id_);
-      GuidConverter remote_conv(remote.repo_id_);
-      VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::initiate_connect_i - "
-                          "pending association marked for removal already, after connecting datalink between local %C and remote %C\n",
-                          OPENDDS_STRING(local).c_str(),
-                          OPENDDS_STRING(remote_conv).c_str()), 0);
-      //this occurs if the transport client was told to disassociate while connecting
-      //disassociate cleans up everything except this local AcceptConnectResult whose destructor
-      //should take care of it because link has not been shifted into links_ by use_datalink_i
-      return false;
-
-    }
-
-  }
   GuidConverter local(repo_id_);
   GuidConverter remote_conv(remote.repo_id_);
   VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::initiate_connect_i - "
@@ -509,7 +470,7 @@ TransportClient::PendingAssoc::initiate_connect(TransportClient* tc,
         if (!tc->initiate_connect_i(res, impl, remote, attribs_, guard)) {
           //tc init connect returned false there is no PendingAssoc left in map because use_datalink_i finished elsewhere
           //so don't do anything further with pend and return success or failure up to tc's associate
-          if (res.success_ && !this->removed_) {
+          if (res.success_ ) {
             GuidConverter local(tc->repo_id_);
             GuidConverter remote(this->data_.remote_id_);
             VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) PendingAssoc::initiate_connect - ")
@@ -600,18 +561,11 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
     return;
   }
 
-  PendingAssoc* pend = iter->second;
+  PendingAssoc_rch pend = iter->second;
   const int active_flag = pend->active_ ? ASSOC_ACTIVE : 0;
   bool ok = false;
 
-  if (pend->removed_) { // no-op
-    VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::use_datalink_i "
-                        "TransportClient(%@) using datalink[%@] pending association to remote %C was removed\n",
-                        this,
-                        link.in(),
-                        OPENDDS_STRING(peerId_conv).c_str()), 0);
-    return;
-  } else if (link.is_nil()) {
+  if (link.is_nil()) {
 
     if (pend->active_ && pend->initiate_connect(this, guard)) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::use_datalink_i "
@@ -643,12 +597,10 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
   }
 
   pending_.erase(iter);
-  pend->removed_ = true;
 
   guard.release();
 
   pending_assoc_timer_->cancel_timer(this, pend);
-  pending_assoc_timer_->delete_pending_assoc(pend);
 
   transport_assoc_done(active_flag | (ok ? ASSOC_OK : 0), remote_id);
 }
@@ -708,13 +660,7 @@ void
 TransportClient::stop_associating()
 {
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
-
-  PendingMap::iterator iter = pending_.begin();
-
-  while (iter != pending_.end()) {
-    iter->second->removed_ = true;
-    ++iter;
-  }
+  pending_.clear();
 }
 
 void
@@ -726,11 +672,7 @@ TransportClient::stop_associating(const GUID_t* repos, CORBA::ULong length)
     return;
   } else {
     for (CORBA::ULong i = 0; i < length; ++i) {
-      PendingMap::iterator iter = pending_.find(repos[i]);
-
-      if (iter != pending_.end()) {
-        iter->second->removed_ = true;
-      }
+      pending_.erase(repos[i]);
     }
   }
 }
@@ -752,10 +694,7 @@ TransportClient::disassociate(const RepoId& peerId)
 
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
 
-  const PendingMap::iterator iter = pending_.find(peerId);
-
-  if (iter != pending_.end()) {
-    iter->second->removed_ = true;
+  if (pending_.erase(peerId)) {
     return;
   }
 


### PR DESCRIPTION
…cts.

The manual managnement for the lifetime of TransportClient::PendingAssoc 
objects fails occasionally because there’s no guarantee a PendingAssoc
object is no longer referenced by another thread when it is about to be 
deleted.

TransportClient::initiate_connect_i() had some logic to detect whether 
a PendingAssoc object was deleted or not before it returned to the 
caller (TransportClient::PendingAssoc::initiate_connect). However, it 
made the return value “false” from TransportClient::initiate_connect_i() 
ambiguous because it could mean connection failure or successfully 
connected but the PendingAssoc object is deleted already. This made it 
hard for the caller to avoid accessing the deleted object.